### PR TITLE
适配官方GPT-5系列模型变更

### DIFF
--- a/app/src/main/java/com/skythinker/gptassistant/api/ChatApiClient.java
+++ b/app/src/main/java/com/skythinker/gptassistant/api/ChatApiClient.java
@@ -154,12 +154,14 @@ public class ChatApiClient {
                         .tools(functions)
                         .toolChoice(ToolChoice.Choice.AUTO.getName())
                         .temperature(temperature)
+                        .maxTokens(null)
                         .build();
             } else {
                 chatCompletion = ChatCompletion.builder()
                         .messages(messageList)
                         .model(model.replaceAll("\\*$","")) // 去掉自定义模型结尾的*号
                         .temperature(temperature)
+                        .maxTokens(null)
                         .build();
             }
         } else { // 含有附件，使用contentList格式
@@ -233,12 +235,14 @@ public class ChatApiClient {
                         .tools(functions)
                         .toolChoice(ToolChoice.Choice.AUTO.getName())
                         .temperature(temperature)
+                        .maxTokens(null)
                         .build();
             } else {
                 chatCompletion = ChatCompletionWithPicture.builder()
                         .messages(messageList)
                         .model(model.replaceAll("\\*$","")) // 去掉自定义Vision模型结尾的*号
                         .temperature(temperature)
+                        .maxTokens(null)
                         .build();
             }
         }

--- a/app/src/main/java/com/skythinker/gptassistant/data/GlobalDataHolder.java
+++ b/app/src/main/java/com/skythinker/gptassistant/data/GlobalDataHolder.java
@@ -178,7 +178,7 @@ public class GlobalDataHolder {
     }
 
     public static void loadModelParams() {
-        gptTemperature = sp.getFloat("model_temperature", 0.5f);
+        gptTemperature = sp.getFloat("model_temperature", 1.0f);
         gptMaxContextNum = sp.getInt("max_context_num", 10);
     }
 

--- a/app/src/main/java/com/skythinker/gptassistant/tool/GlobalUtils.java
+++ b/app/src/main/java/com/skythinker/gptassistant/tool/GlobalUtils.java
@@ -63,7 +63,7 @@ public class GlobalUtils {
     }
 
     public static boolean checkVisionSupport(String model) {
-        final String[] specialVisionModels = {"gpt-4-turbo", "gpt-4o", "gpt-4o-mini"}; // 支持识图但不包含"vision"的模型
+        final String[] specialVisionModels = {"gpt-5.2", "gpt-5-mini"}; // 支持识图但不包含"vision"的模型
         return model.contains("vision") || Arrays.asList(specialVisionModels).contains(model) || model.endsWith("*");
     }
 }

--- a/app/src/main/java/com/skythinker/gptassistant/tool/GlobalUtils.java
+++ b/app/src/main/java/com/skythinker/gptassistant/tool/GlobalUtils.java
@@ -63,7 +63,7 @@ public class GlobalUtils {
     }
 
     public static boolean checkVisionSupport(String model) {
-        final String[] specialVisionModels = {"gpt-5.2", "gpt-5-mini"}; // 支持识图但不包含"vision"的模型
+        final String[] specialVisionModels = {"gpt-4-turbo", "gpt-4o", "gpt-4o-mini", "gpt-5.2", "gpt-5-mini", "gpt-5-nano"}; // 支持识图但不包含"vision"的模型
         return model.contains("vision") || Arrays.asList(specialVisionModels).contains(model) || model.endsWith("*");
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,14 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false">GPTAssistant</string>
     <string-array name="models">
-        <item>gpt-5-mini</item>
+        <item>gpt-3.5-turbo</item>
+        <item>gpt-4</item>
+        <item>gpt-4-turbo</item>
+        <item>gpt-4o</item>
+        <item>gpt-4o-mini</item>
         <item>gpt-5.2</item>
+        <item>gpt-5-mini</item>
+        <item>gpt-5-nano</item>
     </string-array>
     <!--  在线资源Url  -->
     <string name="homepage_url_github" translatable="false">https://github.com/Skythinker616/gpt-assistant-android</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false">GPTAssistant</string>
     <string-array name="models">
-        <item>gpt-3.5-turbo</item>
-        <item>gpt-4</item>
-        <item>gpt-4-turbo</item>
-        <item>gpt-4o</item>
-        <item>gpt-4o-mini</item>
+        <item>gpt-5-mini</item>
+        <item>gpt-5.2</item>
     </string-array>
     <!--  在线资源Url  -->
     <string name="homepage_url_github" translatable="false">https://github.com/Skythinker616/gpt-assistant-android</string>


### PR DESCRIPTION
添加GPT-5系列模型 "gpt-5.2", "gpt-5-mini", "gpt-5-nano"

对请求参数进行如下改动确保官方和某些透传请求体的第三方API能够正常使用
移除unfbx.chatgpt过时的max_tokens参数 参考 https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create (更好的方法应该还是换掉停更两年多的unfbx chatgpt库，或者自己构建请求，不过我不懂java，只能针对报错进行临时修补)
将默认温度设置为1(gpt-5系列内置推理的模型仅接受默认值1) 参考 https://community.openai.com/t/temperature-in-gpt-5-models/1337133